### PR TITLE
feat: add submit draft endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,12 @@ repositories {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/GlobalErrorHandler.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/GlobalErrorHandler.java
@@ -3,6 +3,8 @@ package com.github.alvaro.alonso.document_processing_fsm;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentValidationException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
@@ -12,9 +14,6 @@ import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
-
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 
 @Component
 public class GlobalErrorHandler implements ErrorWebExceptionHandler {
@@ -39,29 +38,33 @@ public class GlobalErrorHandler implements ErrorWebExceptionHandler {
         var defaultError = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         defaultError.setType(URI.create("internal-server-error"));
         // TODO: add proper logging
-        System.out.println("Unhandled exception: [" + ex.getClass() + "] [" + ex.getMessage() + "]");
+        System.out.println(
+                "Unhandled exception: [" + ex.getClass() + "] [" + ex.getMessage() + "]");
         ex.printStackTrace();
         return writeResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, defaultError);
     }
 
-    private Mono<Void> writeResponse(ServerHttpResponse response, HttpStatus status, ProblemDetail problemDetail) {
+    private Mono<Void> writeResponse(
+            ServerHttpResponse response, HttpStatus status, ProblemDetail problemDetail) {
         response.setStatusCode(status);
         response.getHeaders().setContentType(MediaType.APPLICATION_PROBLEM_JSON);
 
         try {
             String json = objectMapper.writeValueAsString(problemDetail);
-            DataBuffer buffer = response.bufferFactory().wrap(json.getBytes(StandardCharsets.UTF_8));
+            DataBuffer buffer =
+                    response.bufferFactory().wrap(json.getBytes(StandardCharsets.UTF_8));
             return response.writeWith(Mono.just(buffer));
         } catch (JsonProcessingException e) {
             // Fallback to simple JSON
-            String fallbackJson = String.format(
-                    "{\"type\":\"%s\",\"title\":\"%s\",\"status\":%d,\"detail\":\"%s\"}",
-                    problemDetail.getType(),
-                    problemDetail.getTitle(),
-                    problemDetail.getStatus(),
-                    problemDetail.getDetail()
-            );
-            DataBuffer buffer = response.bufferFactory().wrap(fallbackJson.getBytes(StandardCharsets.UTF_8));
+            String fallbackJson =
+                    String.format(
+                            "{\"type\":\"%s\",\"title\":\"%s\",\"status\":%d,\"detail\":\"%s\"}",
+                            problemDetail.getType(),
+                            problemDetail.getTitle(),
+                            problemDetail.getStatus(),
+                            problemDetail.getDetail());
+            DataBuffer buffer =
+                    response.bufferFactory().wrap(fallbackJson.getBytes(StandardCharsets.UTF_8));
             return response.writeWith(Mono.just(buffer));
         }
     }

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/GlobalErrorHandler.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/GlobalErrorHandler.java
@@ -1,0 +1,68 @@
+package com.github.alvaro.alonso.document_processing_fsm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.alvaro.alonso.document_processing_fsm.document.DocumentValidationException;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class GlobalErrorHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public GlobalErrorHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+
+        ServerHttpResponse response = exchange.getResponse();
+
+        if (ex instanceof DocumentValidationException) {
+            var validationException = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+            validationException.setDetail(ex.getMessage());
+            return writeResponse(response, HttpStatus.BAD_REQUEST, validationException);
+        }
+
+        var defaultError = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        defaultError.setType(URI.create("internal-server-error"));
+        // TODO: add proper logging
+        System.out.println("Unhandled exception: [" + ex.getClass() + "] [" + ex.getMessage() + "]");
+        ex.printStackTrace();
+        return writeResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, defaultError);
+    }
+
+    private Mono<Void> writeResponse(ServerHttpResponse response, HttpStatus status, ProblemDetail problemDetail) {
+        response.setStatusCode(status);
+        response.getHeaders().setContentType(MediaType.APPLICATION_PROBLEM_JSON);
+
+        try {
+            String json = objectMapper.writeValueAsString(problemDetail);
+            DataBuffer buffer = response.bufferFactory().wrap(json.getBytes(StandardCharsets.UTF_8));
+            return response.writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            // Fallback to simple JSON
+            String fallbackJson = String.format(
+                    "{\"type\":\"%s\",\"title\":\"%s\",\"status\":%d,\"detail\":\"%s\"}",
+                    problemDetail.getType(),
+                    problemDetail.getTitle(),
+                    problemDetail.getStatus(),
+                    problemDetail.getDetail()
+            );
+            DataBuffer buffer = response.bufferFactory().wrap(fallbackJson.getBytes(StandardCharsets.UTF_8));
+            return response.writeWith(Mono.just(buffer));
+        }
+    }
+}

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
@@ -1,15 +1,32 @@
 package com.github.alvaro.alonso.document_processing_fsm.document;
 
 import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentState;
+import jakarta.validation.constraints.NotBlank;
 
 public record Document(
+
         String id,
+
+        @NotBlank
         String title,
+
+        @NotBlank
         String content,
+
+        @NotBlank
         String author,
+
+        @NotBlank
         DocumentState state,
+
+        @NotBlank(groups = ReviewValidation.class)
         String reviewer) {
     public Document withState(DocumentState state) {
         return new Document(id, title, content, author, state, reviewer);
     }
+
+    public interface ReviewValidation {}
 }
+
+
+

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
@@ -5,29 +5,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record Document(
-
         String id,
-
-        @NotBlank (message = "Document title not provided")
-        String title,
-
-        @NotBlank (message = "Document content not provided")
-        String content,
-
-        @NotBlank (message = "Document author not provided")
-        String author,
-
-        @NotNull(message = "Document state not provided")
-        DocumentState state,
-
-        @NotBlank(groups = ReviewValidation.class)
-        String reviewer) {
+        @NotBlank(message = "Document title not provided") String title,
+        @NotBlank(message = "Document content not provided") String content,
+        @NotBlank(message = "Document author not provided") String author,
+        @NotNull(message = "Document state not provided") DocumentState state,
+        @NotBlank(groups = ReviewValidation.class) String reviewer) {
     public Document withState(DocumentState state) {
         return new Document(id, title, content, author, state, reviewer);
     }
 
     public interface ReviewValidation {}
 }
-
-
-

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/Document.java
@@ -2,21 +2,22 @@ package com.github.alvaro.alonso.document_processing_fsm.document;
 
 import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentState;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record Document(
 
         String id,
 
-        @NotBlank
+        @NotBlank (message = "Document title not provided")
         String title,
 
-        @NotBlank
+        @NotBlank (message = "Document content not provided")
         String content,
 
-        @NotBlank
+        @NotBlank (message = "Document author not provided")
         String author,
 
-        @NotBlank
+        @NotNull(message = "Document state not provided")
         DocumentState state,
 
         @NotBlank(groups = ReviewValidation.class)

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentEventException.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentEventException.java
@@ -1,8 +1,0 @@
-package com.github.alvaro.alonso.document_processing_fsm.document;
-
-public class DocumentEventException extends Exception {
-
-    public DocumentEventException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentHandler.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentHandler.java
@@ -1,0 +1,33 @@
+package com.github.alvaro.alonso.document_processing_fsm.document;
+import jakarta.validation.Validator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+public class DocumentHandler {
+
+
+    private final Validator validator;
+
+    private final DocumentService documentService;
+
+    public DocumentHandler(DocumentService documentService, Validator validator) {
+        this.documentService = documentService;
+        this.validator = validator;
+    }
+
+    public Mono<ServerResponse> submit(ServerRequest req) {
+        Mono<Document> documentMono = req.bodyToMono(Document.class);
+
+        return documentMono
+//                .doOnNext(this.validator::validate)
+                .flatMap((doc) -> Mono.just(documentService.submitDraft(doc)))
+                .flatMap((document) -> ServerResponse.status(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(document));
+    }
+}

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentRouter.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentRouter.java
@@ -1,0 +1,26 @@
+package com.github.alvaro.alonso.document_processing_fsm.document;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+@Configuration(proxyBeanMethods = false)
+public class DocumentRouter {
+
+    @Bean
+    public RouterFunction<ServerResponse> documentRoutes (DocumentHandler documentHandler) {
+        return route()
+                .path("/api/v1/document", baseRoute -> baseRoute
+                        .nest(accept(APPLICATION_JSON), baseContentType -> baseContentType
+                        .POST("/submit", documentHandler::submit)))
+                .build();
+
+
+    }
+}

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentRouter.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentRouter.java
@@ -1,26 +1,27 @@
 package com.github.alvaro.alonso.document_processing_fsm.document;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
-
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
-import static org.springframework.web.reactive.function.server.RouterFunctions.route;
-
 @Configuration(proxyBeanMethods = false)
 public class DocumentRouter {
 
     @Bean
-    public RouterFunction<ServerResponse> documentRoutes (DocumentHandler documentHandler) {
-        return route()
-                .path("/api/v1/document", baseRoute -> baseRoute
-                        .nest(accept(APPLICATION_JSON), baseContentType -> baseContentType
-                        .POST("/submit", documentHandler::submit)))
+    public RouterFunction<ServerResponse> documentRoutes(DocumentHandler documentHandler) {
+        return route().path(
+                        "/api/v1/document",
+                        baseRoute ->
+                                baseRoute.nest(
+                                        accept(APPLICATION_JSON),
+                                        baseContentType ->
+                                                baseContentType.POST(
+                                                        "/submit", documentHandler::submit)))
                 .build();
-
-
     }
 }

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentService.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentService.java
@@ -3,7 +3,9 @@ package com.github.alvaro.alonso.document_processing_fsm.document;
 import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentEventType;
 import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentState;
 import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentStateMachine;
+import org.springframework.stereotype.Service;
 
+@Service
 public class DocumentService {
     private final DocumentStateMachine stateMachine;
 

--- a/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentValidationException.java
+++ b/src/main/java/com/github/alvaro/alonso/document_processing_fsm/document/DocumentValidationException.java
@@ -1,0 +1,8 @@
+package com.github.alvaro.alonso.document_processing_fsm.document;
+
+public class DocumentValidationException extends RuntimeException {
+
+    public DocumentValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: document-processing-fsm
+  webflux:
+    problemdetails:
+      enabled: true

--- a/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
+++ b/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
@@ -1,5 +1,7 @@
 package com.github.alvaro.alonso.document_processing_fsm;
 
+import static org.mockito.Mockito.when;
+
 import com.github.alvaro.alonso.document_processing_fsm.document.Document;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentHandler;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentRouter;
@@ -16,25 +18,23 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static org.mockito.Mockito.when;
-
 @WebFluxTest
 @Import({DocumentRouter.class, DocumentHandler.class, GlobalErrorHandler.class})
 @AutoConfigureWebTestClient
 public class DocumentRouterTest {
 
-    @Autowired
-    private WebTestClient webTestClient;
+    @Autowired private WebTestClient webTestClient;
 
-    @MockitoBean
-    private DocumentService service;
+    @MockitoBean private DocumentService service;
 
     static final String API_URL = "/api/v1/document";
     static final String SUBMIT_URL = API_URL + "/submit";
 
     @Test
     void submitDocument() {
-        var document = new Document(null, "test-doc", "lorem ipsum", "some-id", DocumentState.SUBMITTED, null);
+        var document =
+                new Document(
+                        null, "test-doc", "lorem ipsum", "some-id", DocumentState.SUBMITTED, null);
 
         when(service.submitDraft(document)).thenReturn(document);
 
@@ -65,7 +65,10 @@ public class DocumentRouterTest {
                 .expectStatus()
                 .isBadRequest()
                 .expectBody(ProblemDetail.class)
-                .isEqualTo(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Document author not provided, Document content not provided, Document state not provided, Document title not provided"));
+                .isEqualTo(
+                        ProblemDetail.forStatusAndDetail(
+                                HttpStatus.BAD_REQUEST,
+                                "Document author not provided, Document content not provided,"
+                                    + " Document state not provided, Document title not provided"));
     }
-
 }

--- a/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
+++ b/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
@@ -1,0 +1,51 @@
+package com.github.alvaro.alonso.document_processing_fsm;
+
+import com.github.alvaro.alonso.document_processing_fsm.document.Document;
+import com.github.alvaro.alonso.document_processing_fsm.document.DocumentHandler;
+import com.github.alvaro.alonso.document_processing_fsm.document.DocumentRouter;
+import com.github.alvaro.alonso.document_processing_fsm.document.DocumentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.mockito.Mockito.when;
+
+@WebFluxTest
+@Import({DocumentRouter.class, DocumentHandler.class})
+@AutoConfigureWebTestClient
+public class DocumentRouterTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private DocumentService service;
+
+    static final String API_URL = "/api/v1/document";
+    static final String SUBMIT_URL = API_URL + "/submit";
+
+    @Test
+    void submitDocument() {
+
+        // TODO: introduce validation
+        var document = new Document(null, null, null, null, null, null);
+
+        when(service.submitDraft(document)).thenReturn(document);
+
+        webTestClient
+                .post()
+                .uri(SUBMIT_URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(document)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectBody(Document.class);
+    }
+
+}

--- a/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
+++ b/src/test/java/com/github/alvaro/alonso/document_processing_fsm/DocumentRouterTest.java
@@ -4,19 +4,22 @@ import com.github.alvaro.alonso.document_processing_fsm.document.Document;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentHandler;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentRouter;
 import com.github.alvaro.alonso.document_processing_fsm.document.DocumentService;
+import com.github.alvaro.alonso.document_processing_fsm.document.fsm.DocumentState;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.mockito.Mockito.when;
 
 @WebFluxTest
-@Import({DocumentRouter.class, DocumentHandler.class})
+@Import({DocumentRouter.class, DocumentHandler.class, GlobalErrorHandler.class})
 @AutoConfigureWebTestClient
 public class DocumentRouterTest {
 
@@ -31,9 +34,7 @@ public class DocumentRouterTest {
 
     @Test
     void submitDocument() {
-
-        // TODO: introduce validation
-        var document = new Document(null, null, null, null, null, null);
+        var document = new Document(null, "test-doc", "lorem ipsum", "some-id", DocumentState.SUBMITTED, null);
 
         when(service.submitDraft(document)).thenReturn(document);
 
@@ -46,6 +47,25 @@ public class DocumentRouterTest {
                 .expectStatus()
                 .isCreated()
                 .expectBody(Document.class);
+    }
+
+    @Test
+    void submitDocumentFailsValidation() {
+
+        var document = new Document(null, null, null, null, null, null);
+
+        when(service.submitDraft(document)).thenReturn(document);
+
+        webTestClient
+                .post()
+                .uri(SUBMIT_URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(document)
+                .exchange()
+                .expectStatus()
+                .isBadRequest()
+                .expectBody(ProblemDetail.class)
+                .isEqualTo(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Document author not provided, Document content not provided, Document state not provided, Document title not provided"));
     }
 
 }


### PR DESCRIPTION
## Description

- Add submit draft endpoint
- Add some validation to the document 
- Add a Global Error handler that maps responses to https://datatracker.ietf.org/doc/html/rfc7807

Out of scope for this PR: Add logging

## Test

- Unit tests added
- TODO: consider adding a base integration test