### PR TITLE
ci: improve checks and scope them to PR only

### DIFF
--- a/.github/actions/setup-java-gradle/action.yml
+++ b/.github/actions/setup-java-gradle/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup Java and Gradle'
+description: 'Set up JDK 24 and Gradle for the project'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 24
+      uses: actions/setup-java@v4
+      with:
+        java-version: '24'
+        distribution: 'temurin'
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Assemble
         run: ./gradlew assemble
 
-    unit-test:
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-      needs: assemble
-      steps:
-        - name: Setup Java and Gradle
-          uses: ./.github/actions/setup-java-gradle
-        - name: Run unit tests
-          run: ./gradlew test
+  unit-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: assemble
+    steps:
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
+      - name: Run unit tests
+        run: ./gradlew test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,6 @@
 name: Checks
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -18,23 +16,13 @@ jobs:
 
       - name: Formatting checks
         run: ./gradlew spotlessCheck
-  assemble:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Java and Gradle
-        uses: ./.github/actions/setup-java-gradle
-      - name: Assemble
-        run: ./gradlew assemble
 
   unit-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: assemble
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Run unit tests

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,18 +7,33 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  format:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
 
       - name: Formatting checks
         run: ./gradlew spotlessCheck
-
-      - name: Build and test
+  assemble:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
+      - name: Assemble
         run: ./gradlew assemble
+
+    unit-test:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+      needs: assemble
+      steps:
+        - name: Setup Java and Gradle
+          uses: ./.github/actions/setup-java-gradle
+        - name: Run unit tests
+          run: ./gradlew test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
 
@@ -22,6 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Assemble

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,17 +14,8 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
-        with:
-          java-version: '24'
-          distribution: 'temurin'
-
-      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
 
       - name: Formatting checks
         run: ./gradlew spotlessCheck


### PR DESCRIPTION
## Description

- Use reusable action to setup JDK and gradle
- Split out gradle tasks in different jobs so CI can fail fast and more granularly